### PR TITLE
Extra test cases for deep fetch and a fix for to-one relationship cache

### DIFF
--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestNotificationDuringDeepFetch.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestNotificationDuringDeepFetch.java
@@ -982,9 +982,10 @@ public class TestNotificationDuringDeepFetch extends MithraTestAbstract
         Assert.assertEquals(4, orderList2.asEcList().flatCollect(getOrderStatusOfOrder).size());
         Assert.assertEquals(4, orderList2.asEcList().flatCollect(getOrderStatusOfOrder).count(orderStatusEqualsTen));
 
-        // todo: for non-bypassCache case these relationship retrievals do not reflect the update because the CachedQuery did not invalidate, whereas the equivalent operation on a ToMany does invalidate. Is this correct?
-        Assert.assertEquals(bypassCache ? 5 : 4, orderList2.getOrderStatus().size());
-        Assert.assertEquals(bypassCache ? 5 : 4, orderList2.getOrderStatus().asEcList().count(orderStatusEqualsTen));
+        // This includes the OrderStatus for order 55 because OrderList.getOrderStatus() does a new finder query which hits the database due to the stale query cache.
+        // It gives the correct results but there is scope to optimise the performance if we could adopt a more sophisticated strategy.
+        Assert.assertEquals(5, orderList2.getOrderStatus().size());
+        Assert.assertEquals(5, orderList2.getOrderStatus().asEcList().count(orderStatusEqualsTen));
 
         allowAllFetches();
 


### PR DESCRIPTION
I added some more test cases. There's only one issue I found, which I've included a fix for.

I've also included the test cases for everything else I tested as we may as well have them to improve the test coverage.

The issue I found is that an update to the parent table during a to-one deep fetch will cause the ToOne strategy to cache the child relationship query with the wrong (future) update count for the parent. This results in receiving stale results if querying the relationship finder for the entire parent list, which is inconsistent with how it works for to-many, and also inconsistent with the behaviour for deep fetch using bypassCache, since that hits a different code path that doesn't have the same bug. The fix was straightforward, using the same principle as your other fixes I included the parent query in a CachedQueryPair. See my third commit for details ('Fix ToOne relationship query not expiring on parent update').

FYI, I had mentioned earlier today that I expected a timing issue with cacheResults but after checking in detail I realise this was actually already fixed by your original change. I hadn't noticed til now that you were checking the child table query for expiry for this case. I'd assumed it would be checking only the parent query like it was doing in other cases before you added the CachedQueryPair. That's a nice fix btw.

I checked a lot of other cases and couldn't see anything else wrong, so I think this is it.